### PR TITLE
Sends the JsonFilter to relays as it was setup by the lib user

### DIFF
--- a/nostrpostrlib/src/main/java/nostr/postr/Relay.kt
+++ b/nostrpostrlib/src/main/java/nostr/postr/Relay.kt
@@ -90,11 +90,7 @@ class Relay(
             } ?: error("No filter(s) found.")
             //Client.filters.map { JsonFilter(it.ids, it.authors, it.kinds, it.tags, since = reconnectTs) }
         } else {
-            Client.subscriptions[requestId]?.let {
-                it.map { filter ->
-                    JsonFilter(filter.ids, filter.authors, filter.kinds, filter.tags)
-                }
-            } ?: error("No filter(s) found.")
+            Client.subscriptions[requestId] ?: error("No filter(s) found.")
         }
         val request = """["REQ","$requestId",${filters.joinToString(",") { it.toJson() }}]"""
         socket.send(request)


### PR DESCRIPTION
I am not sure why the lib recreates the JsonFilter before sending it to relays but, since it works correctly without recreating, it feels like this was an oversight. 

More specifically, my app needs the `since` and `until` filter parameters to be sent over to be performant. 

I am happy to look into other ways to use the lib if this PR is incorrect. 

Thank you for the great work. 